### PR TITLE
params variable added for binding job's parameters

### DIFF
--- a/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
+++ b/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
@@ -66,6 +66,7 @@ public class FlowDSL {
                 out: listener.logger,
                 env: envMap,
                 upstream: upstream,
+                params: flowRun.getBuildVariables(),
                 SUCCESS: SUCCESS,
                 UNSTABLE: Result.UNSTABLE,
                 FAILURE: Result.FAILURE,


### PR DESCRIPTION
This just adds binding for job's parameters. It's accessible thru params["param_name"]
