### PR TITLE
add publisher support

### DIFF
--- a/src/main/java/com/cloudbees/plugins/flow/BuildFlow.java
+++ b/src/main/java/com/cloudbees/plugins/flow/BuildFlow.java
@@ -21,11 +21,23 @@ import hudson.Extension;
 import hudson.model.*;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Queue.FlyweightTask;
+import hudson.tasks.BuildStep;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Fingerprinter;
 import hudson.tasks.Publisher;
+import hudson.Util;
 import hudson.util.AlternativeUiTextProvider;
 import hudson.util.DescribableList;
+
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
 import javax.servlet.ServletException;
+
+import net.sf.json.JSONObject;
+
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -34,11 +46,14 @@ import org.kohsuke.stapler.StaplerResponse;
  *
  * @author <a href="mailto:nicolas.deloof@cloudbees.com">Nicolas De loof</a>
  */
-public class BuildFlow extends AbstractProject<BuildFlow, FlowRun> implements TopLevelItem, FlyweightTask, SCMedItem {
+public class BuildFlow extends AbstractProject<BuildFlow, FlowRun> implements TopLevelItem, FlyweightTask, Saveable, SCMedItem {
 
     private final FlowIcon icon = new FlowIcon();
 
     private String dsl;
+
+    private DescribableList<Publisher, Descriptor<Publisher>> publishers = 
+        new DescribableList<Publisher, Descriptor<Publisher>>(this);
 
     public BuildFlow(ItemGroup parent, String name) {
         super(parent, name);
@@ -53,9 +68,27 @@ public class BuildFlow extends AbstractProject<BuildFlow, FlowRun> implements To
     }
 
     @Override
+    public DescribableList<Publisher, Descriptor<Publisher>> getPublishersList() {
+        return publishers;
+    }
+
+    /**
+     * Returns the list of publishers. This method is used to initialize the config-publishers view with the data
+     * stored in the publishers data member. Without this method defined the config-publishers view is always
+     * initialized to defaults.
+     */
+    public Map<Descriptor<Publisher>,Publisher> getPublishers() {
+        return publishers.toMap();
+    }
+
+    @Override
     protected void submit(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException, FormException {
         super.submit(req, rsp);
-        this.dsl = req.getSubmittedForm().getString("dsl");
+
+        JSONObject json = req.getSubmittedForm();
+
+        this.dsl = json.getString("dsl");
+        publishers.rebuild(req, json, BuildStepDescriptor.filter(Publisher.all(), this.getClass()));
     }
 
     @Extension
@@ -87,29 +120,40 @@ public class BuildFlow extends AbstractProject<BuildFlow, FlowRun> implements To
     }
 
     @Override
-    public DescribableList<Publisher, Descriptor<Publisher>> getPublishersList() {
-        return new DescribableList<Publisher,Descriptor<Publisher>>(this);
-    }
-
-    @Override
     protected Class<FlowRun> getBuildClass() {
         return FlowRun.class;
     }
 
     @Override
     public boolean isFingerprintConfigured() {
-        // TODO Auto-generated method stub
-        return false;
+        return getPublishersList().get(Fingerprinter.class)!=null;
     }
 
     @Override
     protected void buildDependencyGraph(DependencyGraph graph) {
-        // TODO Auto-generated method stub
-        
+        /* XXX: Examine the build flow to determine all possible downstream projects. */
+        publishers.buildDependencyGraph(this, graph);
     }
 
-	public AbstractProject<?, ?> asProject() {
-		return (AbstractProject) this;
-	} 
-    
+    @Override
+    protected Set<ResourceActivity> getResourceActivities() {
+        final Set<ResourceActivity> activities = new HashSet<ResourceActivity>();
+
+        activities.addAll(super.getResourceActivities());
+        activities.addAll(Util.filter(publishers,ResourceActivity.class));
+        return activities;
+    }
+
+    protected List<Action> createTransientActions() {
+        List<Action> r = super.createTransientActions();
+
+        for(BuildStep p : getPublishersList())
+            r.addAll(p.getProjectActions(this));
+
+        return r;
+    }
+
+    public AbstractProject<?, ?> asProject() {
+      return this;
+    } 
 }

--- a/src/main/java/com/cloudbees/plugins/flow/BuildFlowPlugin.java
+++ b/src/main/java/com/cloudbees/plugins/flow/BuildFlowPlugin.java
@@ -18,11 +18,11 @@
 package com.cloudbees.plugins.flow;
 
 import hudson.Plugin;
+import hudson.model.Items;
 
 /**
  * @author <a href="mailto:nicolas.deloof@cloudbees.com">Nicolas De loof</a>
  */
 public class BuildFlowPlugin extends Plugin {
-
 
 }

--- a/src/main/java/com/cloudbees/plugins/flow/FlowRun.java
+++ b/src/main/java/com/cloudbees/plugins/flow/FlowRun.java
@@ -31,6 +31,7 @@ import org.jgrapht.graph.SimpleDirectedGraph;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
+import static hudson.model.Result.FAILURE;
 import static hudson.model.Result.SUCCESS;
 
 /**
@@ -125,6 +126,9 @@ public class FlowRun extends AbstractBuild<BuildFlow, FlowRun>{
         }
 
         protected Result doRun(BuildListener listener) throws Exception {
+            if(!preBuild(listener, project.getPublishersList()))
+                return FAILURE;
+
             try {
                 setResult(SUCCESS);
                 new FlowDSL().executeFlowScript(FlowRun.this, dsl, listener);
@@ -144,10 +148,13 @@ public class FlowRun extends AbstractBuild<BuildFlow, FlowRun>{
 
         @Override
         public void post2(BuildListener listener) throws IOException, InterruptedException {
+            if(!performAllBuildSteps(listener, project.getPublishersList(), true))
+                setResult(FAILURE);
         }
 
         @Override
         public void cleanUp(BuildListener listener) throws Exception {
+            performAllBuildSteps(listener, project.getPublishersList(), false);
             super.cleanUp(listener);
         }
     }

--- a/src/main/resources/com/cloudbees/plugins/flow/BuildFlow/configure-entries.jelly
+++ b/src/main/resources/com/cloudbees/plugins/flow/BuildFlow/configure-entries.jelly
@@ -21,11 +21,13 @@
   </f:entry>
 
   <p:config-disableBuild/>
-  
+
   <p:config-concurrentBuild/>
-  
-  <p:config-trigger/>
-    
+
+  <p:config-trigger>
+      <p:config-upstream-pseudo-trigger />
+  </p:config-trigger>
+
   <f:section title="${%Advanced Project Options configure-common}">
     <f:advanced>
       <p:config-quietPeriod />
@@ -35,6 +37,6 @@
       <st:include page="configure-advanced.jelly" optional="true" />
     </f:advanced>
   </f:section>
-    
 
+  <p:config-publishers />
 </j:jelly>


### PR DESCRIPTION
Adds support for configuring publishers. 
This patch was built by studying hudson.model.Project for relevant code and copying over to BuildFlow. I only tested publisher execution by verifying the trigger job publisher worked. 

I suspect other project types that support publishers also have similar code in their class definitions. 
