### PR TITLE
Rename FlowRun.schedule to run. Plus some error handling.

### DIFF
--- a/src/main/java/com/cloudbees/plugins/flow/FlowRun.java
+++ b/src/main/java/com/cloudbees/plugins/flow/FlowRun.java
@@ -31,6 +31,7 @@ import org.jgrapht.graph.SimpleDirectedGraph;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
+import static hudson.model.Result.FAILURE;
 import static hudson.model.Result.SUCCESS;
 
 /**
@@ -64,12 +65,15 @@ public class FlowRun extends AbstractBuild<BuildFlow, FlowRun>{
         state.set(new FlowState(SUCCESS, this));
     }
 
-    /* package */ Run schedule(JobInvocation job, List<Action> actions) throws ExecutionException, InterruptedException {
-        job.run(new FlowCause(this),actions);
-        addBuild(job.getBuild());
-        job.waitForCompletion();
-        getState().setResult(job.getResult());
-        return job.getBuild();
+    /* package */ Run run(JobInvocation job, List<Action> actions) throws ExecutionException, InterruptedException {
+        Boolean could_run = job.run(new FlowCause(this),actions);
+        if(could_run) {
+            addBuild(job.getBuild());
+            getState().setResult(job.getResult());
+            return job.getBuild();
+        } else {
+            return null;
+        }
     }
 
     /* package */ FlowState getState() {

--- a/src/main/java/com/cloudbees/plugins/flow/JobInvocation.java
+++ b/src/main/java/com/cloudbees/plugins/flow/JobInvocation.java
@@ -30,9 +30,9 @@ public class JobInvocation {
         }
     }
 
-    /* package */ JobInvocation run(Cause cause, List<Action> actions) {
+    /* package */ Boolean run(Cause cause, List<Action> actions) {
         future = project.scheduleBuild2(project.getQuietPeriod(), cause, actions);
-        return this;
+        return future != null;
     }
 
 
@@ -53,10 +53,5 @@ public class JobInvocation {
 
     public String toString() {
         return "running job :" + name;
-    }
-
-    public void waitForCompletion() throws ExecutionException, InterruptedException {
-        Run run = getBuild();
-        while(run.isBuilding()) Thread.sleep(1000);
     }
 }


### PR DESCRIPTION
"schedule" implied the procedure did not wait for the job to complete.
"run" is ambiguous, but at least not misleading.
The core JobInvocation.run method can return null in some cases. This presents this error to the
user in a clearer fashion.
