### PR TITLE
Proposal to support parametrized jobs using their default values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 *.iml
 *.ipr
 *.iws
+.idea
+

--- a/src/test/groovy/com/cloudbees/plugins/flow/BuildTest.groovy
+++ b/src/test/groovy/com/cloudbees/plugins/flow/BuildTest.groovy
@@ -20,6 +20,14 @@ package com.cloudbees.plugins.flow
 import static hudson.model.Result.SUCCESS
 import static hudson.model.Result.FAILURE
 import hudson.model.Job
+import hudson.model.Action
+import hudson.model.ParametersAction
+import hudson.model.ParameterValue
+import hudson.model.StringParameterValue
+import hudson.model.ParametersDefinitionProperty
+import hudson.model.ParameterDefinition
+import hudson.model.StringParameterDefinition
+import hudson.model.FreeStyleProject
 
 class BuildTest extends DSLTestCase {
 
@@ -104,6 +112,24 @@ class BuildTest extends DSLTestCase {
         def build = assertSuccess(job2)
         assertHasParameter(build, "param1", "SUCCESS")
         assertHasParameter(build, "param2", "job1")
+        assert SUCCESS == flow.result
+    }
+
+    public void testParametersFromBuildWithDefaultValues() {
+        FreeStyleProject job1 = createJob("job1")
+        def parametersDefinitions = new ParametersDefinitionProperty(new StringParameterDefinition("param1", "0"), new StringParameterDefinition("param2", "0"))
+        job1.addProperty(parametersDefinitions)
+
+        def flow = run("""
+            b = build("job1",
+                  param1:"1",
+                  param3:"3")
+        """)
+
+        def build = assertSuccess(job1)
+        assertHasParameter(build, "param1", "1")
+        assertHasParameter(build, "param2", "0")
+        assertHasParameter(build, "param3", "3")
         assert SUCCESS == flow.result
     }
 }


### PR DESCRIPTION
The bug:
- When the build flow call some jobs with parameters, setting only one of the values then the other values are not set to there default one.
- This forces to set all values to parametrized jobs.

Problem to solve :
- Create a freestyle job "Parametrized Job" with a StringParameter PARAM which default value is 0, and a sh step like 'echo PARAM=${PARAM}'
- Create a build-flow job containing :
  build("Parametrized Job", PARAM:"1")
- Run the build-flow

RESULT:
- Parametrize Job console contains " PARAM= "

EXPECTED:
- Parametrize Job console contains " PARAM=0"
