### PR TITLE
Fixed JENKINS-17199

### DIFF
--- a/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
+++ b/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
@@ -17,6 +17,10 @@
 
 package com.cloudbees.plugins.flow
 
+import hudson.util.spring.ClosureScript
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.codehaus.groovy.control.customizers.ImportCustomizer
+
 import java.util.logging.Logger
 import jenkins.model.Jenkins
 import hudson.model.*
@@ -40,17 +44,7 @@ import org.acegisecurity.context.SecurityContextHolder
 
 public class FlowDSL {
 
-    private ExpandoMetaClass createEMC(Class scriptClass, Closure cl) {
-        ExpandoMetaClass emc = new ExpandoMetaClass(scriptClass, false)
-        cl(emc)
-        emc.initialize()
-        return emc
-    }
-
     def void executeFlowScript(FlowRun flowRun, String dsl, BuildListener listener) {
-        // TODO : add restrictions for System.exit, etc ...
-        FlowDelegate flow = new FlowDelegate(flowRun, listener)
-
         // Retrieve the upstream build if the flow was triggered by another job
         AbstractBuild upstream = null;
         flowRun.causes.each{ cause -> 
@@ -70,32 +64,19 @@ public class FlowDSL {
         Jenkins.instance.globalNodeProperties.each(getEnvVars)
         flowRun.builtOn.nodeProperties.each(getEnvVars)
 
-        def binding = new Binding([
-                build: flowRun,
-                out: listener.logger,
-                env: envMap,
-                upstream: upstream,
-                params: flowRun.getBuildVariables(),
-                SUCCESS: SUCCESS,
-                UNSTABLE: Result.UNSTABLE,
-                FAILURE: Result.FAILURE,
-                ABORTED: Result.ABORTED,
-                NOT_BUILT: Result.NOT_BUILT
-        ])
+        // TODO : add restrictions for System.exit, etc ...
+        FlowDelegate flow = new FlowDelegate(flowRun, listener, upstream, envMap)
 
-        Script dslScript = new GroovyShell(binding).parse("flow { " + dsl + "}")
-        dslScript.metaClass = createEMC(dslScript.class, {
-            ExpandoMetaClass emc ->
-            emc.flow = {
-                Closure cl ->
-                cl.delegate = flow
-                cl.resolveStrategy = Closure.DELEGATE_FIRST
-                cl()
-            }
-            emc.println = {
-                String s -> flow.println s
-            }
-        })
+
+        // parse the script in such a way that it delegates to the flow object as default
+        def cc = new CompilerConfiguration();
+        cc.scriptBaseClass = ClosureScript.class.name;
+        def ic = new ImportCustomizer()
+        ic.addStaticStars(Result.class.name)
+        cc.addCompilationCustomizers(ic)
+
+        ClosureScript dslScript = (ClosureScript)new GroovyShell(Jenkins.instance.pluginManager.uberClassLoader,new Binding(),cc).parse(dsl)
+        dslScript.setDelegate(flow);
 
         try {
             dslScript.run()
@@ -112,6 +93,7 @@ public class FlowDSL {
     // TODO define a parseFlowScript to validate flow DSL and maintain jobs dependencygraph
 }
 
+@SuppressWarnings("GroovyUnusedDeclaration")
 public class FlowDelegate {
 
     private static final Logger LOGGER = Logger.getLogger(FlowDelegate.class.getName());
@@ -119,11 +101,15 @@ public class FlowDelegate {
     def FlowRun flowRun
     BuildListener listener
     int indent = 0
+    private AbstractBuild upstream;
+    private Map env;
 
-    public FlowDelegate(FlowRun flowRun, BuildListener listener) {
+    public FlowDelegate(FlowRun flowRun, BuildListener listener, upstream, env) {
         this.flowRun = flowRun
         this.listener = listener
         causes = flowRun.causes
+        this.upstream = upstream
+        this.env = env
     }
 
     def getOut() {
@@ -150,6 +136,28 @@ public class FlowDelegate {
 
     def build(String jobName) {
         build([:], jobName)
+    }
+
+    def getBuild() {
+        return flowRun;
+    }
+
+    def getParams() {
+        return flowRun.buildVariables;
+    }
+
+    /**
+     * Upstream build that triggered this flow execution, if any.
+     */
+    AbstractBuild getUpstream() {
+        return upstream;
+    }
+
+    /**
+     * Environment variables that the build gets from its context.
+     */
+    Map<String,String> getEnv() {
+        return env
     }
 
     /**

--- a/src/test/groovy/com/cloudbees/plugins/flow/BindingTest.groovy
+++ b/src/test/groovy/com/cloudbees/plugins/flow/BindingTest.groovy
@@ -17,6 +17,8 @@
 
 package com.cloudbees.plugins.flow
 
+import hudson.model.Result
+
 import static hudson.model.Result.SUCCESS
 import static hudson.model.Result.FAILURE
 import hudson.model.Job
@@ -53,4 +55,11 @@ class BindingTest extends DSLTestCase {
         assert SUCCESS == flow.result
     }
 
+    public void testBuiltinImports() {
+        def flow = run("""
+            println "test="+SUCCESS.class.name;
+        """)
+        assert SUCCESS == flow.result
+        assert flow.log.contains("test="+ Result.SUCCESS.class.name)
+    }
 }

--- a/src/test/groovy/com/cloudbees/plugins/flow/BuildTest.groovy
+++ b/src/test/groovy/com/cloudbees/plugins/flow/BuildTest.groovy
@@ -17,6 +17,9 @@
 
 package com.cloudbees.plugins.flow
 
+import hudson.model.Result
+import org.jvnet.hudson.test.Bug
+
 import static hudson.model.Result.SUCCESS
 import static hudson.model.Result.FAILURE
 import hudson.model.Job
@@ -156,5 +159,15 @@ class BuildTest extends DSLTestCase {
         assertHasParameter(build, "param2", "0")
         assertHasParameter(build, "param3", "3")
         assert SUCCESS == flow.result
+    }
+
+    @Bug(17199)
+    public void testImportStatement() {
+        def flow = run("""
+            import java.util.Date;
+            println "Hello from date: "+new Date();
+        """)
+        assert SUCCESS == flow.result
+        assert flow.log.contains("Hello from date: ")
     }
 }


### PR DESCRIPTION
To inject DSL into the script being parsed, the common technique used
elsewhere (for example in Spring bean builder Groovy DSL) is to set
the DSL object as a delegate. This avoids the need to do string
manipulation, and there's no ExpandoMetaClass hack necessary.

I'v moved the bindings to FlowDelegate. This resolves
the conflict between "build" as a variable and "build" as a function
(since binding gets found more quickly it tries to evaluate that
variable as a Callable), and it'll also make it easier for people to
find all the available DSL methods/variables in one place.
