### PR TITLE
Added a mechanism to define DSL extensions

### DIFF
--- a/src/main/java/com/cloudbees/plugins/flow/BuildFlowDSLExtension.java
+++ b/src/main/java/com/cloudbees/plugins/flow/BuildFlowDSLExtension.java
@@ -1,0 +1,37 @@
+package com.cloudbees.plugins.flow;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import jenkins.model.Jenkins;
+
+/**
+ * Extends BuildFlow DSL by inserting additional methods/properties.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+public abstract class BuildFlowDSLExtension implements ExtensionPoint {
+    /**
+     * Creates a new DSL extension object.
+     *
+     * @param extensionName
+     *      String that identifies the extension.
+     *      This string should primarily the artifact ID of the plugin,
+     *      such as "external-resource-dispatcher". The consist naming between extension
+     *      and plugin name makes it easier for users to use extensions
+     *      from an untyped scripting environment of Groovy.
+     *
+     *      If a plugin needs to expose multiple extensions from a single plugin,
+     *      append suffix to the artifact ID, for example "external-resource-dispatcher.manager"
+     *
+     * @return
+     *      null if this extension doesn't understand the specified extension name.
+     */
+    public abstract Object createExtension(String extensionName, FlowDelegate dsl);
+
+    /**
+     * All the installed extensions.
+     */
+    public static ExtensionList<BuildFlowDSLExtension> all() {
+        return Jenkins.getInstance().getExtensionList(BuildFlowDSLExtension.class);
+    }
+}

--- a/src/test/groovy/com/cloudbees/plugins/flow/BuildFlowDSLExtensionTest.groovy
+++ b/src/test/groovy/com/cloudbees/plugins/flow/BuildFlowDSLExtensionTest.groovy
@@ -1,0 +1,21 @@
+package com.cloudbees.plugins.flow
+
+import com.cloudbees.plugin.flow.TestDSLExtension
+import hudson.model.Result
+
+class BuildFlowDSLExtensionTest extends DSLTestCase {
+
+    public void testUseExtension() {
+        BuildFlowDSLExtension.all().add(new TestDSLExtension())
+        def flow = run("""
+            x = extension.test123
+            println "name="+x.name
+            println "dsl="+x.dsl.class.name
+        """)
+        System.out.println flow.log
+        assert Result.SUCCESS == flow.result
+        assert flow.log.contains("name=test123")
+        assert flow.log.contains("dsl="+FlowDelegate.class.name)
+    }
+
+}

--- a/src/test/java/com/cloudbees/plugin/flow/TestDSLExtension.java
+++ b/src/test/java/com/cloudbees/plugin/flow/TestDSLExtension.java
@@ -1,0 +1,22 @@
+package com.cloudbees.plugin.flow;
+
+import com.cloudbees.plugins.flow.BuildFlowDSLExtension;
+import com.cloudbees.plugins.flow.FlowDelegate;
+import hudson.Extension;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * @author Kohsuke Kawaguchi
+ */
+@Extension
+public class TestDSLExtension extends BuildFlowDSLExtension {
+    @Override
+    public Object createExtension(String extensionName, FlowDelegate dsl) {
+        Map m = new TreeMap();
+        m.put("dsl",dsl);
+        m.put("name",extensionName);
+        return m;
+    }
+}


### PR DESCRIPTION
This pull request defines a mechanism to load extensions into BuildFlow plugin, without polluting the namespace.

With this change the user would write something like this:

```
def x = extension.foobar
def y = extension."external-resource-dispatcher"

x.anotherMethod()
println y.someProperty
```

The backend is an obvious implementaion based on `ExtensionPoint` and `@Extension` like everywhere you see in Jenkins.
