### PR TITLE
fixing path to flow.png

### DIFF
--- a/src/main/java/com/cloudbees/plugins/flow/BuildFlowAction.java
+++ b/src/main/java/com/cloudbees/plugins/flow/BuildFlowAction.java
@@ -42,7 +42,7 @@ public class BuildFlowAction implements BuildBadgeAction {
     }
 
     public String getIconFileName() {
-        return "/plugin/build-flow-plugin/images/16x16/flow.png";
+        return "flow.png";
     }
 
     public String getDisplayName() {


### PR DESCRIPTION
When running jenkins with a prefix (ie. http://jenkinsserver/jenkins/... rather than http://jenkinsserver/) as when running in tomcat or behind a reverse-proxy, the icon for build-flow jobs is broken. This changes it from a hard-coded path to simply "flow.png", which allows Jenkins to automatically locate the icon.
