### PR TITLE
Adding the actual job description and job name to graph if set

### DIFF
--- a/src/main/resources/com/cloudbees/plugins/flow/FlowRun/build-step.jelly
+++ b/src/main/resources/com/cloudbees/plugins/flow/FlowRun/build-step.jelly
@@ -7,7 +7,7 @@
         data-row="${job.displayRow}"
         style="background-color: ${job.colorForHtml};">
         <div class="title">
-        	<a href="${job.buildUrl}">${job.build.fullDisplayName}</a>
+            <a href="${job.buildUrl}">${job.build.fullDisplayName}</a>
         </div>
         <div class="details">
             <j:if test="${!empty(job.build.description)}">


### PR DESCRIPTION
This is a small adaptation to the Build Flow Plugin graph. It adds the actual job description and job name if this is set. Only the jelly-script is updated.

Using this script:
build.setDescription("My flow description")
build.setDisplayName("MyName")

test1 = build("Test1").build
test1.setDescription("Description set by user")
test1.setDisplayName("NameMe")
test1.setDescription()

test2 = build("Test2").build
test2.setDescription("Description set by user")
test2.setDisplayName("NameMe")
test2.setDisplayName()

build("Test1").build

Will create the following graph:
![build_flow_naming](https://f.cloud.github.com/assets/4181469/423768/46d86076-ad6e-11e2-8ec9-38803b8b81b6.png)

The code is a contribution from Ericsson AB (http://www.ericsson.com/) and has been reviewed internally by Marco Miller (https://github.com/marco-miller)
