### PR TITLE
[FIXED JENKINS-18003]

### DIFF
--- a/src/main/groovy/com/cloudbees/plugins/flow/JobInvocation.groovy
+++ b/src/main/groovy/com/cloudbees/plugins/flow/JobInvocation.groovy
@@ -87,7 +87,7 @@ public class JobInvocation {
 
     public Result getResult() throws ExecutionException, InterruptedException {
         waitForCompletion();
-        return build.getResult();
+        return getBuild().getResult();
     }
 
     public String getResultString() throws ExecutionException, InterruptedException {
@@ -96,8 +96,8 @@ public class JobInvocation {
 
     public String getColorForHtml() {
         BallColor color = BallColor.NOTBUILT;
-        if (build != null) {
-            color = build.getIconColor();
+        if (getBuild() != null) {
+            color = getBuild().getIconColor();
         }
         return color.getHtmlBaseColor();
     }
@@ -153,16 +153,16 @@ public class JobInvocation {
     }
 
     public String getBuildUrl() {
-        return this.build != null ? this.build.getAbsoluteUrl() : null;
+        return this.getBuild() != null ? this.getBuild().getAbsoluteUrl() : null;
     }
 
     public String getStartTime() {
         String formattedStartTime = "";
-        if (build.getTime() != null) {
+        if (getBuild().getTime() != null) {
             formattedStartTime = DateFormat.getDateTimeInstance(
                 DateFormat.SHORT,
                 DateFormat.SHORT)
-                .format(build.getTime());
+                .format(getBuild().getTime());
         }
         return formattedStartTime;
     }

--- a/src/main/java/com/cloudbees/plugins/flow/FlowRun.java
+++ b/src/main/java/com/cloudbees/plugins/flow/FlowRun.java
@@ -52,9 +52,9 @@ public class FlowRun extends Build<BuildFlow, FlowRun> {
     
     private String dsl;
 
-    private JobInvocation.Start startJob = new JobInvocation.Start(this);
+    private JobInvocation.Start startJob;
 
-    private DirectedGraph<JobInvocation, JobEdge> jobsGraph = new SimpleDirectedGraph<JobInvocation, JobEdge>(JobEdge.class);
+    private DirectedGraph<JobInvocation, JobEdge> jobsGraph;
 
     private transient ThreadLocal<FlowState> state = new ThreadLocal<FlowState>();
     
@@ -71,6 +71,12 @@ public class FlowRun extends Build<BuildFlow, FlowRun> {
     }
 
     private void setup(BuildFlow job) {
+        if (jobsGraph == null) {
+            jobsGraph = new SimpleDirectedGraph<JobInvocation, JobEdge>(JobEdge.class);
+        }
+        if (startJob == null) {
+            startJob = new JobInvocation.Start(this);
+        }
         this.dsl = job.getDsl();
         startJob.buildStarted(this);
         jobsGraph.addVertex(startJob);


### PR DESCRIPTION
I looked into the sources and it turned out that build graph is persisted in build.xml, but when it is loaded, it is overwritten by field initializer in FlowRun.java. 

Also, in JobInvocation.groovy some build fields are returned without using getBuild() method, so lazy wiring JobInvocation object with actual Build object is skipped causing all builds displayed as not started on a graph loaded from disk.

This requests fixes both problems.
