### PR TITLE
JobInvocation.toString includes build.displayName

### DIFF
--- a/src/main/groovy/com/cloudbees/plugins/flow/JobInvocation.groovy
+++ b/src/main/groovy/com/cloudbees/plugins/flow/JobInvocation.groovy
@@ -188,7 +188,7 @@ public class JobInvocation {
     }
 
     public String toString() {
-        return name + (build != null ? " #" + build.number : "");
+        return name + (build != null ? build.displayName : "");
     }
 
     public void waitForCompletion() throws ExecutionException, InterruptedException {


### PR DESCRIPTION
JobInvocation.toString is used in the graph view for FlowRuns. When the
build name is set, e.g. with the Build Name Setter plugin, this makes a
big improvement to the interface.
