### PR TITLE
Include arbitrary Actions and BuildParameters into the called Job.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,25 @@
             <artifactId>jgrapht-jdk1.5</artifactId>
             <version>0.7.3</version>
         </dependency>
+        <!-- we contribute AbstractBuildParameters it's available -->
+	    <dependency>
+	      <groupId>org.jvnet.hudson.plugins</groupId>
+	      <artifactId>parameterized-trigger</artifactId>
+	      <version>2.4</version>
+	      <optional>true</optional>
+	      <exclusions> <!-- Excluding subversion to make sure we don't inadvertently pick up the Oracle Hudson "2.0" svn plugin and break the build. -->
+	        <exclusion>
+	          <groupId>org.jvnet.hudson.plugins</groupId>
+	          <artifactId>subversion</artifactId>
+	        </exclusion>
+	      </exclusions>
+	    </dependency>
+	    <dependency>
+		    <groupId>org.jenkinsci.plugins</groupId>
+			<artifactId>git</artifactId>
+			<version>1.1.20</version> 
+			<optional>true</optional>
+	    </dependency>
     </dependencies>
   
   <repositories>

--- a/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
+++ b/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
@@ -24,9 +24,6 @@ import org.codehaus.groovy.control.customizers.ImportCustomizer
 import java.util.logging.Logger
 import jenkins.model.Jenkins
 import hudson.model.*
-import hudson.plugins.git.GitRevisionBuildParameters;
-import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
-import hudson.plugins.parameterizedtrigger.SubversionRevisionBuildParameters;
 import static hudson.model.Result.SUCCESS
 import java.util.concurrent.Executors
 import java.util.concurrent.ExecutorService
@@ -185,7 +182,7 @@ public class FlowDelegate {
             if (it instanceof Closure) it = getClosureValue(it)
             if (it instanceof Action) {
                 actions.add(it)
-            } else if (Jenkins.getInstance().getPlugin("parameterized-trigger") != null && it instanceof AbstractBuildParameters) {
+            } else if (Jenkins.getInstance().getPlugin("parameterized-trigger") != null && it instanceof hudson.plugins.parameterizedtrigger.AbstractBuildParameters) {
                 actions.add(it.getAction(flowRun, listener))
             } else { 
                 println("Invalid Parameter, only action or buildParameter allowed (found: ${it.class.name})")
@@ -502,7 +499,7 @@ class DynamicBuildParamExtensionLoader {
     def methodMissing(String name, Object args) {
         name = StringUtils.capitalize(name)
         
-        def v = Jenkins.getInstance().getDescriptorList(AbstractBuildParameters.class).find { it.klass.toJavaClass().simpleName.startsWith(name) }.klass.toJavaClass() 
+        def v = Jenkins.getInstance().getDescriptorList(hudson.plugins.parameterizedtrigger.AbstractBuildParameters.class).find { it.klass.toJavaClass().simpleName.startsWith(name) }.klass.toJavaClass() 
         if (v==null)
             throw new UnsupportedOperationException("No such Build-Parameter available: "+name)
         return v.newInstance(args)

--- a/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
+++ b/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
@@ -24,6 +24,9 @@ import org.codehaus.groovy.control.customizers.ImportCustomizer
 import java.util.logging.Logger
 import jenkins.model.Jenkins
 import hudson.model.*
+import hudson.plugins.git.GitRevisionBuildParameters;
+import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
+import hudson.plugins.parameterizedtrigger.SubversionRevisionBuildParameters;
 import static hudson.model.Result.SUCCESS
 import java.util.concurrent.Executors
 import java.util.concurrent.ExecutorService
@@ -41,6 +44,7 @@ import java.util.concurrent.ExecutionException
 import java.util.concurrent.CopyOnWriteArrayList
 import hudson.security.ACL
 import org.acegisecurity.context.SecurityContextHolder
+import org.apache.commons.lang.StringUtils;
 
 public class FlowDSL {
 
@@ -134,8 +138,8 @@ public class FlowDelegate {
         throw new JobExecutionFailureException()
     }
 
-    def build(String jobName) {
-        build([:], jobName)
+    def build(String jobName, Object... actionsOrParams) {
+        build([:], jobName, actionsOrParams)
     }
 
     def getBuild() {
@@ -169,15 +173,27 @@ public class FlowDelegate {
         }
     }
 
-    def build(Map args, String jobName) {
+    def build(Map args, String jobName, Object... actionsOrParams) {
         statusCheck()
         // ask for job with name ${name}
         JobInvocation job = new JobInvocation(flowRun, jobName)
         Job p = job.getProject()
         println("Trigger job " + HyperlinkNote.encodeTo('/'+ p.getUrl(), p.getFullDisplayName()))
 
-
-        Run r = flowRun.run(job, getActions(p, args));
+        def actions = getActions(p, args)
+        for (Object it: actionsOrParams) {
+            if (it instanceof Closure) it = getClosureValue(it)
+            if (it instanceof Action) {
+                actions.add(it)
+            } else if (Jenkins.getInstance().getPlugin("parameterized-trigger") != null && it instanceof AbstractBuildParameters) {
+                actions.add(it.getAction(flowRun, listener))
+            } else { 
+                println("Invalid Parameter, only action or buildParameter allowed (found: ${it.class.name})")
+                fail();
+            }
+        }
+        
+        Run r = flowRun.run(job, actions);
         if (null == r) {
             println("Failed to start ${jobName}.")
             fail();
@@ -231,8 +247,7 @@ public class FlowDelegate {
             }
             if (paramValue instanceof Boolean) {
                 params.add(new BooleanParameterValue(paramName, (Boolean) paramValue))
-            }
-            else {
+            } else {
                 params.add(new StringParameterValue(paramName, paramValue.toString()))
             }
             addedParams.add(paramName);
@@ -257,7 +272,7 @@ public class FlowDelegate {
             }
         }
 
-        //Additionnal parameters not available in the target job
+        //Additional parameters not available in the target job
         actions.add(new ParametersAction(params));
         return actions
     }
@@ -431,7 +446,22 @@ public class FlowDelegate {
     def getExtension() {
         return new DynamicExtensionLoader(this);
     }
-
+    
+    /**
+     * Create BuildParameters (parametrized triggers plugin).
+     * 
+     * <p>
+     * For example,
+     *
+     * <pre>
+     * build("job1", withParam.gitRevision )
+     * build("job2", withParam.gitRevision(true), withParam.svnRevision)
+     * </pre>
+     */
+    def getWithParam() {
+        return new DynamicBuildParamExtensionLoader(this);
+    }
+    
     def propertyMissing(String name) {
         throw new MissingPropertyException("Property ${name} doesn't exist.");
     }
@@ -455,5 +485,26 @@ class DynamicExtensionLoader {
         if (v==null)
             throw new UnsupportedOperationException("No such extension available: "+name)
         return v;
+    }
+}
+
+class DynamicBuildParamExtensionLoader {
+    FlowDelegate outer;
+
+    DynamicBuildParamExtensionLoader(FlowDelegate outer) {
+        this.outer = outer
+    }
+
+    def propertyMissing(name) {
+        methodMissing(name, new Object[0])
+    }
+    
+    def methodMissing(String name, Object args) {
+        name = StringUtils.capitalize(name)
+        
+        def v = Jenkins.getInstance().getDescriptorList(AbstractBuildParameters.class).find { it.klass.toJavaClass().simpleName.startsWith(name) }.klass.toJavaClass() 
+        if (v==null)
+            throw new UnsupportedOperationException("No such Build-Parameter available: "+name)
+        return v.newInstance(args)
     }
 }

--- a/src/test/groovy/com/cloudbees/plugins/flow/BuildFlowWitParamExtensionTest.groovy
+++ b/src/test/groovy/com/cloudbees/plugins/flow/BuildFlowWitParamExtensionTest.groovy
@@ -1,0 +1,24 @@
+package com.cloudbees.plugins.flow
+
+import jenkins.model.Jenkins;
+
+import com.cloudbees.plugin.flow.TestDSLExtension
+import hudson.model.Result
+import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
+
+class BuildFlowWitParamExtensionTest extends DSLTestCase {
+
+    public void testUseParams() {
+        def flow = run("""
+            def p = withParam.subversionRevision
+            def p2 = withParam.gitRevision()
+            def p3 = withParam.predefined("a=b")
+
+            println p.class
+            println p2.class
+        """)
+        System.out.println flow.log
+        assert Result.SUCCESS == flow.result
+    }
+
+}

--- a/src/test/groovy/com/cloudbees/plugins/flow/BuildTest.groovy
+++ b/src/test/groovy/com/cloudbees/plugins/flow/BuildTest.groovy
@@ -22,6 +22,7 @@ import org.jvnet.hudson.test.Bug
 
 import static hudson.model.Result.SUCCESS
 import static hudson.model.Result.FAILURE
+import hudson.model.InvisibleAction;
 import hudson.model.Job
 import hudson.model.Action
 import hudson.model.ParametersAction
@@ -160,6 +161,28 @@ class BuildTest extends DSLTestCase {
         assertHasParameter(build, "param3", "3")
         assert SUCCESS == flow.result
     }
+    
+    public void testBuildWithAction() {
+        Job job1 = createJob("job1")
+        def flow = run("""
+            build("job1", new com.cloudbees.plugins.flow.BuildTest.DummyAction())
+        """)
+        def build = assertSuccess(job1)
+        assertHasAction(build, DummyAction.class)
+        assert SUCCESS == flow.result
+    }
+
+    public void testBuildWithParam() {
+        Job job1 = createJob("job1")
+        def flow = run("""
+                build("job1", new hudson.plugins.parameterizedtrigger.PredefinedBuildParameters("a=b"))
+        """)
+        def build = assertSuccess(job1)
+        assertHasParameter(build, "a", "b")
+        assert SUCCESS == flow.result
+    }
+    
+    public static class DummyAction extends InvisibleAction {}
 
     @Bug(17199)
     public void testImportStatement() {

--- a/src/test/groovy/com/cloudbees/plugins/flow/DSLTestCase.groovy
+++ b/src/test/groovy/com/cloudbees/plugins/flow/DSLTestCase.groovy
@@ -136,10 +136,20 @@ abstract class DSLTestCase extends HudsonTestCase {
         assertTrue("build don't have expected parameter set " + name + "=" + value, found)
     }
 
-    void assertRan(Job job, int times, Result result) {
+    void assertHasAction(Job job, Class actionClass) {
+        assertHasParameter(job.builds.lastBuild, actionClass)
+    }
+
+    void assertHasAction(AbstractBuild build, Class actionClass) {
+        assertNotNull("Build has no action of type ${actionClass}", build.getAction(actionClass))
+    }
+
+     void assertRan(Job job, int times, Result result) {
         assert job.builds.size() == times
         job.builds.each { build ->
             assert build.result == result
         }
     }
+    
+    
 }


### PR DESCRIPTION
Actions and BuildParameters can be added as additional parameters to the
build call.

Also added a convenience statement "withParam", which tries to map the
following statement to a BuildParameter (optionally with arguments).

Example: build("my-job", param1: "x", withParam.gitRevision)

Where git Revision is mapped to GitRevisionBuildParameters from
Git-Plugin.

This is especially useful to have the build-flow job as director, starting a whole chain of builds using the same revision.