### PR TITLE
Fixed groovy.lang.MissingFieldException: No such field: uid

### DIFF
--- a/src/main/groovy/com/cloudbees/plugins/flow/JobInvocation.groovy
+++ b/src/main/groovy/com/cloudbees/plugins/flow/JobInvocation.groovy
@@ -233,7 +233,7 @@ public class JobInvocation {
     boolean equals(Object obj) {
         if (!(obj instanceof JobInvocation)) return false
         JobInvocation other = (JobInvocation) obj
-        return uid == other.uid;
+        return hashCode() == other.hashCode();
     }
 
     @Override


### PR DESCRIPTION
Fixes the following error:
        ...
    at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1061)
    at hudson.util.XStream2.unmarshal(XStream2.java:109)
    at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1045)
    at hudson.XmlFile.unmarshal(XmlFile.java:166)
    ... 144 more
Caused by: groovy.lang.MissingFieldException: No such field: uid for class: com.cloudbees.plugins.flow.JobInvocation
    at groovy.lang.MetaClassImpl.getAttribute(MetaClassImpl.java:2482)
    at groovy.lang.MetaClassImpl.getAttribute(MetaClassImpl.java:3308)
    at org.codehaus.groovy.runtime.InvokerHelper.getAttribute(InvokerHelper.java:127)
    at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.getField(ScriptBytecodeAdapter.java:302)
    at com.cloudbees.plugins.flow.JobInvocation$Start.propertyMissing(JobInvocation.groovy)
    at sun.reflect.GeneratedMethodAccessor79.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90)
    at groovy.lang.MetaClassImpl.invokeMissingProperty(MetaClassImpl.java:752)
    at groovy.lang.MetaClassImpl$11.getProperty(MetaClassImpl.java:1761)
    at org.codehaus.groovy.runtime.callsite.GetEffectivePogoPropertySite.callGroovyObjectGetProperty(GetEffectivePogoPropertySite.java:67)
    at com.cloudbees.plugins.flow.JobInvocation.equals(JobInvocation.groovy:236)
    at java.util.HashMap.put(HashMap.java:376)
    at com.thoughtworks.xstream.converters.collections.MapConverter.putCurrentEntryIntoMap(MapConverter.java:93)
    at com.thoughtworks.xstream.converters.collections.MapConverter.populateMap(MapConverter.java:78)
    at com.thoughtworks.xstream.converters.collections.MapConverter.populateMap(MapConverter.java:72)
    at com.thoughtworks.xstream.converters.collections.MapConverter.unmarshal(MapConverter.java:67)
    at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:72)
    ... 171 more
