### PR TITLE
print stracktrace to log when parallell builds fail

### DIFF
--- a/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
+++ b/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
@@ -412,6 +412,8 @@ public class FlowDelegate {
                 {
                     // TODO perhaps rethrow?
                     current_state.result = FAILURE
+                    listener.error("Failed to run DSL Script")
+                    e.printStackTrace(listener.getLogger())
                 }
             }
 


### PR DESCRIPTION
When a build in a parallell fails nothing is printed, this makes it very hard to debug/develop code containing the parallell action. 

This will print the stacktrace but will not rethrow the exception, meaning other jobs in the parallell action will continue.
