### PR TITLE
[FIXED JENKINS-13914] monospace font in dsl textbox

### DIFF
--- a/src/main/resources/com/cloudbees/plugins/flow/BuildFlow/configure-entries.jelly
+++ b/src/main/resources/com/cloudbees/plugins/flow/BuildFlow/configure-entries.jelly
@@ -33,7 +33,7 @@
   <f:section title="Flow">
     <f:entry field="dsl" title="${%Define build flow using flow DSL}">
       <j:getStatic var="permission" className="hudson.model.Hudson" field="RUN_SCRIPTS"/>
-      <f:textarea readonly="${h.hasPermission(it,permission) ? null : 'readonly'}" />
+      <f:textarea readonly="${h.hasPermission(it,permission) ? null : 'readonly'}" style="font-family:monospace" />
     </f:entry>
   </f:section>
 


### PR DESCRIPTION
Allows for monospaced text in the build flow dsl configuration box.
