### PR TITLE
Add ability to change the requirement for retry

### DIFF
--- a/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
+++ b/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
@@ -358,10 +358,11 @@ public class FlowDelegate {
         }
     }
 
-    def retry(int attempts, retryClosure) {
+    def retry(int attempts, worstAllowed='SUCCESS', retryClosure) {
         statusCheck()
         Result origin = flowRun.state.result
         int i = 0;
+        Result worstAllowedResult = Result.fromString(worstAllowed)
         while( attempts-- > 0) {
             // Restore the pre-retry result state to ignore failures
             flowRun.state.result = origin
@@ -373,7 +374,7 @@ public class FlowDelegate {
 
             --indent
 
-            if (flowRun.state.result.isBetterOrEqualTo(SUCCESS)) {
+            if (flowRun.state.result.isBetterOrEqualTo(worstAllowedResult)) {
                 println("}")
                 return;
             }

--- a/src/test/groovy/com/cloudbees/plugins/flow/RetryTest.groovy
+++ b/src/test/groovy/com/cloudbees/plugins/flow/RetryTest.groovy
@@ -26,6 +26,7 @@ package com.cloudbees.plugins.flow
 
 import hudson.model.Result
 import static hudson.model.Result.SUCCESS
+import static hudson.model.Result.UNSTABLE
 import static hudson.model.Result.FAILURE
 import hudson.model.Job
 
@@ -108,6 +109,17 @@ class RetryTest extends DSLTestCase {
         assertRan(rescue, 3, SUCCESS)
         assert FAILURE == flow.result
         println flow.jobsGraph.edgeSet()
+    }
+
+    public void testNoRetryUnstable() {
+        Job job1 = createUnstableJob("job1")
+        def flow = run("""
+            retry(3, 'UNSTABLE') {
+                build("job1")
+            }
+        """)
+        assertRan(job1, 1, UNSTABLE)
+        assert UNSTABLE == flow.result
     }
 
 


### PR DESCRIPTION
In many of our job configurations, an unstable result means the testing process went smoothly, but not everything passed. Conversely, a failure usually indicates an unexpected build failure (network issue, etc), which will likely perform properly when retried.

Includes one test - I didn't think it would be necessary to test all cases as performed for success, but if necessary I can add those as well.

``` groovy
retry(3, 'UNSTABLE', {
  build('job-where-unstable-is-acceptable-result')
})
```
