### PR TITLE
Improved equals() and hashCode()

### DIFF
--- a/src/main/groovy/com/cloudbees/plugins/flow/JobInvocation.groovy
+++ b/src/main/groovy/com/cloudbees/plugins/flow/JobInvocation.groovy
@@ -153,6 +153,10 @@ public class JobInvocation {
     public String getName() {
         return name;
     }
+    
+    public String getBuildNumber() {
+        return buildNumber;
+    }
 
     public boolean isStarted() {
         return started;
@@ -232,12 +236,11 @@ public class JobInvocation {
     @Override
     boolean equals(Object obj) {
         if (!(obj instanceof JobInvocation)) return false
-        JobInvocation other = (JobInvocation) obj
-        return hashCode() == other.hashCode();
+        return this.name == obj.name && this.buildNumber == obj.buildNumber 
     }
 
     @Override
     int hashCode() {
-        return uid;
+        return name.hashCode();
     }
 }

--- a/src/main/java/com/cloudbees/plugins/flow/FlowDownStreamRunDeclarer.java
+++ b/src/main/java/com/cloudbees/plugins/flow/FlowDownStreamRunDeclarer.java
@@ -48,10 +48,10 @@ public class FlowDownStreamRunDeclarer extends DownStreamRunDeclarer {
             return getOutgoingEdgeRuns(f, f.getStartJob());
         }
 
-        FlowCause flow = (FlowCause) r.getCause(FlowCause.class);
-        if (flow != null) {
-            FlowRun f = flow.getFlowRun();
-            return getOutgoingEdgeRuns(f, flow.getAssociatedJob());
+        FlowCause cause = (FlowCause) r.getCause(FlowCause.class);
+        if (cause != null) {
+            FlowRun f = cause.getFlowRun();
+            return getOutgoingEdgeRuns(f, cause.getAssociatedJob());
         }
 
         return Collections.emptyList();


### PR DESCRIPTION
equals was inaccurate, leading to errors in specific scenarios. To be specific:

A job calling to different flows which in turn call the same subjob ("prepare-environment") in our case using the same index would result in missing entries in the buildgraph.

equals is now based on name and buildnumber, hashCode is based on name.
