### PR TITLE
Form checking for the DSL should use HTTP POST.

### DIFF
--- a/src/main/resources/com/cloudbees/plugins/flow/BuildFlow/configure-entries.jelly
+++ b/src/main/resources/com/cloudbees/plugins/flow/BuildFlow/configure-entries.jelly
@@ -33,7 +33,7 @@
   <f:section title="Flow">
     <f:entry field="dsl" title="${%Define build flow using flow DSL}">
       <j:getStatic var="permission" className="hudson.model.Hudson" field="RUN_SCRIPTS"/>
-      <f:textarea readonly="${h.hasPermission(it,permission) ? null : 'readonly'}" />
+      <f:textarea readonly="${h.hasPermission(it,permission) ? null : 'readonly'}" checkMethod="POST" />
     </f:entry>
   </f:section>
 


### PR DESCRIPTION
As the DSL can get rather large the queryParameter will eventually exceed
the maximum supported GET URL for various servers.

To defend around this use the POST method for checking the DSL.

Jenkins should automatically use post for all textareas, or if @RequirePOST is
set on the doCheckXXX method - however this is not the case and an immediate fix is required.
