### PR TITLE
Made buildgraph-view optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>buildgraph-view</artifactId>
             <version>1.0</version>
+            <optional>true</optional>
         </dependency>
         
         <dependency>

--- a/src/main/java/com/cloudbees/plugins/flow/FlowDownStreamRunDeclarer.java
+++ b/src/main/java/com/cloudbees/plugins/flow/FlowDownStreamRunDeclarer.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ExecutionException;
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-@Extension
+@Extension(optional = true)
 public class FlowDownStreamRunDeclarer extends DownStreamRunDeclarer {
 
     @Override


### PR DESCRIPTION
No reason for this dependency to be mandatory.
