### PR TITLE
add the possibility to read dsl from a file

### DIFF
--- a/src/main/java/com/cloudbees/plugins/flow/BuildFlow.java
+++ b/src/main/java/com/cloudbees/plugins/flow/BuildFlow.java
@@ -64,6 +64,7 @@ public class BuildFlow extends Project<BuildFlow, FlowRun> implements TopLevelIt
     private final FlowIcon icon = new FlowIcon();
 
     private String dsl;
+    private String dslFile;
 
     private boolean buildNeedsWorkspace;
 
@@ -88,13 +89,27 @@ public class BuildFlow extends Project<BuildFlow, FlowRun> implements TopLevelIt
         this.buildNeedsWorkspace = buildNeedsWorkspace;
     }
 
+    public String getDslFile() {
+        return dslFile;
+    }
+
+    public void setDslFile(String dslFile) {
+        this.dslFile = dslFile;
+    }
+
     @Override
     protected void submit(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException, FormException {
         super.submit(req, rsp);
         JSONObject json = req.getSubmittedForm();
-        this.buildNeedsWorkspace = json.getBoolean("buildNeedsWorkspace");
+        this.buildNeedsWorkspace = json.containsKey("buildNeedsWorkspace");
         if (Jenkins.getInstance().hasPermission(Jenkins.RUN_SCRIPTS)) {
             this.dsl = json.getString("dsl");
+            if (this.buildNeedsWorkspace) {
+                JSONObject o = json.getJSONObject("buildNeedsWorkspace");
+                this.dslFile = Util.fixEmptyAndTrim(o.getString("dslFile"));
+            } else {
+                this.dslFile = null;
+            }
         }
     }
 

--- a/src/main/resources/com/cloudbees/plugins/flow/BuildFlow/configure-entries.jelly
+++ b/src/main/resources/com/cloudbees/plugins/flow/BuildFlow/configure-entries.jelly
@@ -31,9 +31,13 @@
   </p:config-trigger>
 
   <f:section title="Flow">
-    <f:entry field="buildNeedsWorkspace" title="${%Flow run needs a workspace}">
-      <f:checkbox/>
-    </f:entry>
+    <f:optionalBlock field="buildNeedsWorkspace" title="${%Flow run needs a workspace}"
+                     checked="${instance.buildNeedsWorkspace}">
+      <f:entry field="dslFile" title="${%Read DSL from file}">
+        <j:getStatic var="permission" className="hudson.model.Hudson" field="RUN_SCRIPTS"/>
+        <f:textbox readonly="${h.hasPermission(it,permission) ? null : 'readonly'}"/>
+      </f:entry>
+    </f:optionalBlock>
     <f:entry field="dsl" title="${%Define build flow using flow DSL}">
       <j:getStatic var="permission" className="hudson.model.Hudson" field="RUN_SCRIPTS"/>
       <f:textarea class="fixed-width" readonly="${h.hasPermission(it,permission) ? null : 'readonly'}" checkMethod="POST" />

--- a/src/main/resources/com/cloudbees/plugins/flow/BuildFlow/help-dslFile.jelly
+++ b/src/main/resources/com/cloudbees/plugins/flow/BuildFlow/help-dslFile.jelly
@@ -1,0 +1,31 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2014, 6WIND
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+    <div>
+       Specify a file path relative to the workspace of the build where the DSL
+       will be read. This option only works if "Flow run needs a workspace" is
+       checked.
+    </div>
+</j:jelly>


### PR DESCRIPTION
This allows to store the DSL under source control with all the benefits
that this can bring. This feature is only available when the "Flow run
needs a workspace" option is enabled.

Signed-off-by: Robin Jarry robin.jarry@6wind.com
