### PR TITLE
Fixes bug causing second level flows to interupt buildgraph

### DIFF
--- a/src/main/java/com/cloudbees/plugins/flow/FlowDownStreamRunDeclarer.java
+++ b/src/main/java/com/cloudbees/plugins/flow/FlowDownStreamRunDeclarer.java
@@ -48,13 +48,16 @@ public class FlowDownStreamRunDeclarer extends DownStreamRunDeclarer {
             return getOutgoingEdgeRuns(f, f.getStartJob());
         }
 
+        List<Run> runs = Collections.emptyList();
         FlowCause flow = (FlowCause) r.getCause(FlowCause.class);
-        if (flow != null) {
-            FlowRun f = flow.getFlowRun();
-            return getOutgoingEdgeRuns(f, flow.getAssociatedJob());
+        FlowRun f;
+        while(runs.isEmpty() && flow != null) {
+        	f = flow.getFlowRun();
+            runs = getOutgoingEdgeRuns(f, flow.getAssociatedJob());
+            flow = (FlowCause) flow.getFlowRun().getCause(FlowCause.class);
         }
 
-        return Collections.emptyList();
+        return runs;
     }
 
     private List<Run> getOutgoingEdgeRuns(FlowRun f, JobInvocation start) throws ExecutionException, InterruptedException {


### PR DESCRIPTION
Do not stop building graph when a recursively called flow is completed.

addressing issues:
https://issues.jenkins-ci.org/browse/JENKINS-23024
https://issues.jenkins-ci.org/browse/JENKINS-19616
