### PR TITLE
Swap dependency to buildgraph-view

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,12 +110,6 @@
             <artifactId>jgrapht-jdk1.5</artifactId>
             <version>0.7.3</version>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>buildgraph-view</artifactId>
-            <version>1.0</version>
-            <optional>true</optional>
-        </dependency>
         
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/com/cloudbees/plugins/flow/DownStreamRunDeclarer.java
+++ b/src/main/java/com/cloudbees/plugins/flow/DownStreamRunDeclarer.java
@@ -1,0 +1,22 @@
+package com.cloudbees.plugins.flow;
+
+import hudson.ExtensionPoint;
+import hudson.model.Run;
+import jenkins.model.Jenkins;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public abstract class DownStreamRunDeclarer implements ExtensionPoint {
+
+
+    public abstract List<Run> getDownStream(Run r) throws ExecutionException, InterruptedException;
+
+    public static List<DownStreamRunDeclarer> all() {
+        return Jenkins.getInstance().getExtensionList(DownStreamRunDeclarer.class);
+    }
+
+}

--- a/src/main/java/com/cloudbees/plugins/flow/FlowDownStreamRunDeclarer.java
+++ b/src/main/java/com/cloudbees/plugins/flow/FlowDownStreamRunDeclarer.java
@@ -26,7 +26,6 @@ package com.cloudbees.plugins.flow;
 
 import hudson.Extension;
 import hudson.model.Run;
-import org.jenkinsci.plugins.buildgraphview.DownStreamRunDeclarer;
 
 import java.util.ArrayList;
 import java.util.Collections;


### PR DESCRIPTION
Swap the dependency so that buildgraph-view is dependent of build-flow-plugin instead of build-flow-plugin being optionally dependent on buildgraph-view. This seems to be the better way to do it since that is how they actually are dependent on each other and buildgraph-view can access functions and classes in the build-flow-plugin that it might need to customize what is shown in the graph.

Closely related to: https://github.com/sjoroos/buildgraph-view/commit/53de75a6f345a639941c274aff819f0aa889e47c
