### PR TITLE
Update JobInvocation.groovy

### DIFF
--- a/src/main/groovy/com/cloudbees/plugins/flow/JobInvocation.groovy
+++ b/src/main/groovy/com/cloudbees/plugins/flow/JobInvocation.groovy
@@ -223,7 +223,7 @@ public class JobInvocation {
     }
 
     public String toString() {
-        return "${name}${displayName}"
+        return "${name}"
     }
 
     public Run waitForStart() throws ExecutionException, InterruptedException {


### PR DESCRIPTION
Version 0.14 of the plugin has a bug where trying to run a job (at least with parameters) causes an exception that property "displayName" is missing. 

This property does not seem to exist on JobInvocation, I am guessing it used to.   

I worked around this issue in my Jenkins script by using metaprogramming, but here is a PR that should make the problem go away.  
