### PR TITLE
Add ability do create build asynchronously and then wait for it when …

### DIFF
--- a/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
+++ b/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
@@ -207,14 +207,22 @@ public class FlowDelegate {
     }
 
     def build(Map args, String jobName) {
-        statusCheck()
+   	   JobInvocation job = buildAsync(args, jobName);
+       return waitForAsyncBuild(job);
+    }
+    def buildAsync(Map args, String jobName){
+    	 statusCheck()
         // ask for job with name ${name}
         JobInvocation job = new JobInvocation(flowRun, jobName)
         Job p = job.getProject()
         println("Schedule job " + HyperlinkNote.encodeTo('/'+ p.getUrl(), p.getFullDisplayName()))
 
         flowRun.schedule(job, getActions(p,args));
-        Run r = job.waitForStart()
+        
+		return job;
+    }
+    def waitForAsyncBuild(JobInvocation job){
+    	Run r = job.waitForStart()
         println("Build " + HyperlinkNote.encodeTo('/'+ r.getUrl(), r.getFullDisplayName()) + " started")
 
         if (null == r) {
@@ -348,7 +356,7 @@ public class FlowDelegate {
         } finally {
 
             final boolean ignore = flowRun.state.result.isBetterOrEqualTo(result)
-            if (ignore) {
+            if (ignore) { 
                 // restore result
                 println("// ${flowRun.state.result} ignored")
                 flowRun.state.result = r


### PR DESCRIPTION
…needed. This will allow to build multiple parallel blocks with common dependency as below (Windows, OSX and Linux all include android builds but they can build their respective dependencies and then wait for android to complete before building final installers):

def allParams = new HashMap(params)
def buildLinux 			= 	buildAsync(allParams,"LINUX")
def buildVC120			= 	buildAsync(allParams,"WINDOWS_VC120")
def buildAndroid 		= 	buildAsync(allParams,"Android")
def buildOSX 			= 	buildAsync(allParams,"OSX")
def buildiOS 			= 	buildAsync(allParams,"iOS")

parallel (
   {
     ignore(FAILURE){
	 	println("Building OS X installer")
     	        waitForAsyncBuild(buildOSX)
	 	waitForAsyncBuild(buildAndroid)
 	 	waitForAsyncBuild(buildiOS)

     	build(allParams,"MacOSXInstaller")
     }
   },
   {
     ignore(FAILURE){
     	println("Building Linux installer")
     	waitForAsyncBuild(buildLinux)
     	waitForAsyncBuild(buildAndroid)
     	build(allParams, "LinuxInstaller")
     }
   },
   {
     ignore(FAILURE){
     	println("Building Windows installer")

     	waitForAsyncBuild(buildVC120)
     	waitForAsyncBuild(buildAndroid)
     	build(allParams,"WindowsInstaller")
     }
   }
)