### PR TITLE
Remove comma in "caused by" link on project page.

### DIFF
--- a/src/main/resources/com/cloudbees/plugins/flow/FlowCause/description.jelly
+++ b/src/main/resources/com/cloudbees/plugins/flow/FlowCause/description.jelly
@@ -1,20 +1,22 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
     <j:set var="proj" value="${app.getItemByFullName(it.buildFlow)}"/>
+    <!-- Use toString to avoid comma-formatted number. -->
+    <j:set var="buildNumberString" value="${it.buildNumber.toString()}"/>
     <j:choose>
         <j:when test="${proj != null}">
             <j:set var="build" value="${proj.getBuildByNumber(it.buildNumber)}"/>
             <j:choose>
                 <j:when test="${build != null}">
-                    ${%message(rootURL, proj.url, it.buildFlow, it.buildNumber)}
+                    ${%message(rootURL, proj.url, it.buildFlow, buildNumberString)}
                 </j:when>
                 <j:otherwise>
-                    ${%message_no_build(rootURL, proj.url, it.buildFlow, it.buildNumber)}
+                    ${%message_no_build(rootURL, proj.url, it.buildFlow, buildNumberString)}
                 </j:otherwise>
             </j:choose>
         </j:when>
         <j:otherwise>
-            ${%message_no_job(rootURL, null, it.buildFlow, it.buildNumber)}
+            ${%message_no_job(rootURL, null, it.buildFlow, buildNumberString)}
         </j:otherwise>
     </j:choose>
     <j:if test="${!it.upstreamCauses.isEmpty()}">


### PR DESCRIPTION
Fixes JENKINS-25664.  Use toString to avoid the comma-formatted number