### PR TITLE
[JENKINS-28430] Add build wrappers configuration section

### DIFF
--- a/src/main/resources/com/cloudbees/plugins/flow/BuildFlow/configure-entries.jelly
+++ b/src/main/resources/com/cloudbees/plugins/flow/BuildFlow/configure-entries.jelly
@@ -30,6 +30,8 @@
       <p:config-upstream-pseudo-trigger />
   </p:config-trigger>
 
+  <p:config-buildWrappers />
+
   <f:section title="Flow">
     <f:optionalBlock field="buildNeedsWorkspace" title="${%Flow run needs a workspace}"
                      checked="${instance.buildNeedsWorkspace}">


### PR DESCRIPTION
[JENKINS-28430](https://issues.jenkins-ci.org/browse/JENKINS-28430)

This allows to use build wrappers in Build Flow jobs, for example `Timestamper Plugin`.

@reviewbybees 