### PR TITLE
Fix build abort when ignoring parallel

### DIFF
--- a/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
+++ b/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
@@ -341,11 +341,20 @@ public class FlowDelegate {
     def ignore(Result result, closure) {
         statusCheck()
         Result r = flowRun.state.result
+        def closureException = null
         try {
             println("ignore("+result+") {")
             ++indent
             closure()
-        } finally {
+        }
+        catch ( Exception ex ) {
+            closureException = ex
+        }
+        finally {
+            // rethrow if there was a non-JobExecutionFailureException Exception
+            if ( closureException != null && !(closureException instanceof JobExecutionFailureException) ) {
+                throw closureException
+            }
 
             final boolean ignore = flowRun.state.result.isBetterOrEqualTo(result)
             if (ignore) {


### PR DESCRIPTION
When the result of a parallel block is ignored, all Exceptions throw by the
parallel monitor thread are ignored.  This means that when the build flow is
aborted, the InterruptedException which would normally abort the build is
suppressed when it should really be re-thrown.

The fix is to always throw Exceptions encountered during an ignore block unless
it is a JobExecutionFailureException.