### PR TITLE
Not to be advertised as a CloudBees plugin any more

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <artifactId>build-flow-plugin</artifactId>
   <version>0.19-SNAPSHOT</version>
   <packaging>hpi</packaging>
-  <name>CloudBees Build Flow plugin</name>
+  <name>Build Flow plugin</name>
   <description>Manages job orchestration as a build flow</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Build+Flow+Plugin</url>
 


### PR DESCRIPTION
As seen [here](http://stackoverflow.com/q/32549856/12916), the current plugin naming leaves the incorrect impression that CloudBees somehow sponsors use of this plugin, or actively maintains it. While it was originally created by a CloudBees employee (IIUC), all company efforts are now being put on Workflow instead, and its current development is entirely from other contributors and maintainers.

BTW the wiki fails to mention the last few releases—oversight?

@reviewbybees