### PR TITLE
[FIXED JENKINS-32144] Specify that a task was cancelled when CancellationException happens

### DIFF
--- a/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
+++ b/src/main/groovy/com/cloudbees/plugins/flow/FlowDSL.groovy
@@ -457,8 +457,12 @@ public class FlowDelegate {
                     Result result = final_state.result
                     results.add(final_state)
                     current_state.result = current_state.result.combine(result)
-                } catch(ExecutionException e)
-                {
+                } catch(CancellationException e) {
+                    // TODO perhaps rethrow?
+                    current_state.result = FAILURE
+                    listener.error("Failed to run DSL Script: At least one of the tasks of the buildflow was cancelled")
+                    e.printStackTrace(listener.getLogger())
+                } catch(ExecutionException e) {
                     // TODO perhaps rethrow?
                     current_state.result = FAILURE
                     listener.error("Failed to run DSL Script")


### PR DESCRIPTION
If a task which is in the queue is cancelled then the following stacktrace happens.
```
Started by user admin
parallel {
    Schedule job test
    Schedule job test2
ERROR: Failed to run DSL Script
java.util.concurrent.ExecutionException: java.util.concurrent.CancellationException
	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.util.concurrent.FutureTask.get(FutureTask.java:188)
	at java_util_concurrent_Future$get.call(Unknown Source)
	at com.cloudbees.plugins.flow.FlowDelegate$_parallel_closure6.doCall(FlowDSL.groovy:456)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:233)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:272)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:903)
	at groovy.lang.Closure.call(Closure.java:415)
	at groovy.lang.Closure.call(Closure.java:428)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:1379)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:1351)
	at org.codehaus.groovy.runtime.dgm$170.invoke(Unknown Source)
```

It might be obvious for some Jenkins users that it has happened because someone or something cancelled the task on the queue, however according with my experience providing Jenkins support it is not for all the users.

https://issues.jenkins-ci.org/browse/JENKINS-32144

@reviewbybees 