### PR TITLE
[FIXED JENKINS-32499] BuildGraph doesn't show up if there is a null run

### DIFF
--- a/src/main/java/com/cloudbees/plugins/flow/FlowDownStreamRunDeclarer.java
+++ b/src/main/java/com/cloudbees/plugins/flow/FlowDownStreamRunDeclarer.java
@@ -64,7 +64,11 @@ public class FlowDownStreamRunDeclarer extends DownStreamRunDeclarer {
         Set<FlowRun.JobEdge> edges = f.getJobsGraph().outgoingEdgesOf(start);
         List<Run> runs = new ArrayList<Run>(edges.size());
         for (FlowRun.JobEdge edge : edges) {
-            runs.add(edge.getTarget().getBuild());
+            JobInvocation targetJobEdge = edge.getTarget();
+            Run run = targetJobEdge.getBuild();
+            if (run != null) {
+                runs.add(run);
+            }
         }
         return runs;
     }


### PR DESCRIPTION
This pull request substitute https://github.com/jenkinsci/buildgraph-view/pull/19 

The steps to re-produce this issue are explaining on the Jira issue.

Basically, the build-graph doesn't show up in case there are null run objects returned by `DownStreamRunDeclarer`.

https://issues.jenkins-ci.org/browse/JENKINS-32499

@reviewbybees 